### PR TITLE
Remove sign up from UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
       <input id="login-email" type="email" placeholder="Email" class="border rounded-xl p-3" />
       <input id="login-password" type="password" placeholder="Contraseña" class="border rounded-xl p-3" />
       <button id="login-btn" class="bg-blue-600 hover:bg-blue-700 text-white rounded-xl p-2 text-sm font-medium">Iniciar sesión</button>
-      <button id="signup-btn" class="bg-gray-200 hover:bg-gray-300 rounded-xl p-2 text-sm font-medium">Registrarse</button>
     </div>
   </section>
 
@@ -511,17 +510,23 @@
     // ===== Supabase Auth =====
     const supabaseUrl = 'https://dqaxkapftyoemlzwbjgx.supabase.co';
     const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRxYXhrYXBmdHlvZW1sendiamd4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg5MjEzMzYsImV4cCI6MjA2NDQ5NzMzNn0.onSRsrHzLpFaVYCdrxYoa8uFD2WDcd2H0PdVEUmM8UA';
-    const supa = supabase.createClient(supabaseUrl, supabaseKey);
+    const supa = supabase.createClient(supabaseUrl, supabaseKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        storageKey: 'sb-badminton-auth',
+      },
+    });
     const loginSection = qs('#login-section');
     const appDiv = qs('#app');
     const emailInputLogin = qs('#login-email');
     const passInputLogin = qs('#login-password');
     const loginBtn = qs('#login-btn');
-    const signupBtn = qs('#signup-btn');
     const logoutBtn = qs('#logout-btn');
 
     async function checkAuth() {
       const { data } = await supa.auth.getSession();
+      console.log('Auth session check:', data.session);
       if (data.session) {
         loginSection.classList.add('hidden');
         appDiv.classList.remove('hidden');
@@ -534,26 +539,28 @@
     }
 
     loginBtn.onclick = async () => {
-      const { error } = await supa.auth.signInWithPassword({
+      const { data, error } = await supa.auth.signInWithPassword({
         email: emailInputLogin.value,
         password: passInputLogin.value,
       });
-      if (error) alert(error.message);
+      if (error) {
+        alert(error.message);
+      } else {
+        console.log('Sesión iniciada:', data);
+        await checkAuth();
+      }
     };
 
-    signupBtn.onclick = async () => {
-      const { error } = await supa.auth.signUp({
-        email: emailInputLogin.value,
-        password: passInputLogin.value,
-      });
-      if (error) alert(error.message);
-    };
 
     logoutBtn.onclick = async () => {
       await supa.auth.signOut();
+      await checkAuth();
     };
 
-    supa.auth.onAuthStateChange(() => checkAuth());
+    supa.auth.onAuthStateChange((event, session) => {
+      console.log('Auth change:', event, session);
+      checkAuth();
+    });
     checkAuth();
 
     /* =================== Init =================== */


### PR DESCRIPTION
## Summary
- remove the "Registrarse" button
- drop the related JavaScript handler
- persist Supabase sessions and log auth events

## Testing
- `npm -v`
- `tidy -errors index.html`


------
https://chatgpt.com/codex/tasks/task_e_683fbd184540832d94b903600631d3f9