### PR TITLE
Add supabase flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,16 @@
     <button id="logout-btn" class="mt-2 text-sm text-red-600 underline">Cerrar sesión</button>
   </header>
 
+  <!-- Birria -->
+  <section id="birria-section" class="card bg-white rounded-2xl p-6 w-full max-w-md hidden">
+    <h2 class="text-xl font-semibold mb-4">Birria actual</h2>
+    <div class="flex flex-col gap-3">
+      <select id="birria-select" class="border rounded-xl p-2"></select>
+      <button id="new-birria" class="bg-green-600 hover:bg-green-700 text-white rounded-xl p-3 text-sm font-medium">Iniciar nueva birria</button>
+      <p id="birria-info" class="text-sm text-gray-600"></p>
+    </div>
+  </section>
+
   <!-- 1. Añadir jugador / Presets -->
   <section class="card bg-white rounded-2xl p-6 w-full max-w-md">
     <h2 class="text-xl font-semibold mb-4 flex items-center gap-2"><span class="i-lucide-user-plus"></span>Añadir jugador</h2>
@@ -65,6 +75,11 @@
     </div>
     <div class="overflow-x-auto">
       <table id="pairings-table" class="w-full text-sm text-center border-collapse"></table>
+    </div>
+    <div id="solo-section" class="mt-4 flex items-center gap-2 hidden">
+      <label for="solo-partner" class="text-sm">Asignar compañero al solo</label>
+      <select id="solo-partner" class="border rounded-xl p-2"></select>
+      <button id="assign-solo" class="bg-blue-600 hover:bg-blue-700 text-white rounded-xl p-2 text-sm font-medium">Asignar</button>
     </div>
   </section>
 
@@ -123,6 +138,9 @@
     const roundSection    = qs('#round-controls');
     const roundTitle      = qs('#round-title');
     const pairTable       = qs('#pairings-table');
+    const soloSection     = qs('#solo-section');
+    const soloPartnerSel  = qs('#solo-partner');
+    const assignSoloBtn   = qs('#assign-solo');
     const nextBtn         = qs('#next');
     const deleteBtn       = qs('#delete-round');
     const resetBtn        = qs('#reset');
@@ -131,6 +149,10 @@
     const matrixSection   = qs('#matrix-section');
     const matrixTable     = qs('#matrix-table');
     const matchSection    = qs('#match-section');
+    const birriaSection   = qs('#birria-section');
+    const newBirriaBtn    = qs('#new-birria');
+    const birriaInfo      = qs('#birria-info');
+    const birriaSelect    = qs('#birria-select');
     const selectRound     = qs('#select-round');
     const selectDuplaA    = qs('#select-dupla-a');
     const selectDuplaB    = qs('#select-dupla-b');
@@ -141,14 +163,86 @@
     let players  = JSON.parse(localStorage.getItem('players')  || '[]');
     let history  = JSON.parse(localStorage.getItem('history')  || '[]');
     let stats    = JSON.parse(localStorage.getItem('stats')    || '{}');
+    let absents  = JSON.parse(localStorage.getItem('absents')  || '[]');
     let round    = history.length;
     let lastExtremes = null;
+    let currentBirriaId = null;
+    let lastRondaId = null;
+    let currentSolo = null;
+    const playersMap = {};
 
     const save = () => {
       localStorage.setItem('players', JSON.stringify(players));
       localStorage.setItem('history', JSON.stringify(history));
       localStorage.setItem('stats',   JSON.stringify(stats));
+      localStorage.setItem('absents', JSON.stringify(absents));
     };
+
+    /* =================== Supabase helpers =================== */
+    async function getPlayerId(name) {
+      if (playersMap[name]) return playersMap[name];
+      let { data, error } = await supa.from('players').select('id').eq('name', name).limit(1);
+      if (error) { console.error(error); return null; }
+      if (data && data.length) {
+        playersMap[name] = data[0].id;
+        return data[0].id;
+      }
+      ({ data, error } = await supa.from('players').insert({ name }).select('id').single());
+      if (error) { console.error(error); return null; }
+      playersMap[name] = data.id;
+      return data.id;
+    }
+
+    async function createBirria() {
+      const play_date = new Date().toISOString().slice(0,10);
+      const { data, error } = await supa
+        .from('birrias')
+        .insert({ play_date })
+        .select('id, play_date')
+        .single();
+      if (error) { console.error(error); return null; }
+      currentBirriaId = data.id;
+      birriaInfo.textContent = `Birria ${data.play_date}`;
+      birriaSection.classList.remove('hidden');
+      newBirriaBtn.classList.add('hidden');
+      await loadBirrias();
+      birriaSelect.value = currentBirriaId;
+      return data.id;
+    }
+
+    async function loadBirrias() {
+      const { data, error } = await supa
+        .from('birrias')
+        .select('id, play_date')
+        .order('play_date', { ascending: false });
+      if (error) { console.error(error); return; }
+      birriaSelect.innerHTML = '<option value="">Elige birria</option>';
+      (data || []).forEach(b => {
+        const opt = document.createElement('option');
+        opt.value = b.id;
+        opt.textContent = b.play_date;
+        birriaSelect.appendChild(opt);
+      });
+      if (currentBirriaId) birriaSelect.value = currentBirriaId;
+    }
+
+    async function saveRoundToSupabase(pairs, num) {
+      if (!currentBirriaId) return null;
+      let { data, error } = await supa.from('rondas').insert({ birria_id: currentBirriaId, round_num: num }).select('id').single();
+      if (error) { console.error(error); return; }
+      const rondaId = data.id;
+      const duplas = [];
+      for (let i=0;i<pairs.length;i++) {
+        const [a,b] = pairs[i];
+        const aId = await getPlayerId(a);
+        const bId = await getPlayerId(b);
+        duplas.push({ ronda_id: rondaId, player_a: aId, player_b: bId, position: i+1 });
+      }
+      const { error: dErr } = await supa.from('duplas').insert(duplas);
+      if (dErr) console.error(dErr);
+      await loadRounds();
+      return rondaId;
+    }
 
     /* =================== Promedio posiciones =================== */
     function record(pairs, solo) {
@@ -191,20 +285,38 @@
       listEl.innerHTML = '';
       players.forEach((p, i) => {
         const li = document.createElement('li');
-        li.className = 'flex justify-between items-center bg-gray-50 rounded-xl p-2 hover:bg-gray-100';
+        const isAbsent = absents.includes(p);
+        li.className = 'flex justify-between items-center bg-gray-50 rounded-xl p-2 hover:bg-gray-100' + (isAbsent ? ' opacity-50' : '');
         li.innerHTML = `<span>${i + 1}. ${p} <span class='text-xs text-gray-500'>(prom: ${avg(p)})</span></span>`;
+
+        const buttons = document.createElement('div');
+
+        const absentBtn = document.createElement('button');
+        absentBtn.textContent = isAbsent ? 'Presente' : 'Ausente';
+        absentBtn.className = 'text-xs border rounded px-2 py-1 mr-2 ' + (isAbsent ? 'bg-green-200' : 'bg-yellow-200');
+        absentBtn.onclick = () => {
+          if (isAbsent) absents = absents.filter(a => a !== p); else absents.push(p);
+          save();
+          renderPlayers();
+          updateMatrixTable();
+        };
+
         const del = document.createElement('button');
         del.innerHTML = '&times;';
         del.className = 'text-red-500 hover:text-red-700';
         del.onclick = () => {
           delete stats[p];
           players.splice(i, 1);
+          absents = absents.filter(a => a !== p);
           updatePresetStyles();
           save();
           renderPlayers();
           updateMatrixTable();
         };
-        li.appendChild(del);
+
+        buttons.appendChild(absentBtn);
+        buttons.appendChild(del);
+        li.appendChild(buttons);
         listEl.appendChild(li);
       });
       updateDatalist();
@@ -220,15 +332,16 @@
         const b = document.createElement('button');
         b.textContent = name;
         b.className = 'preset-button rounded-xl p-2 text-xs font-medium';
-        b.onclick = () => {
-          if (players.includes(name)) return;
-          players.push(name);
-          stats[name] = stats[name] || { sum: 0, count: 0 };
-          save();
-          renderPlayers();
-          updatePresetStyles();
-          updateMatrixTable();
-        };
+      b.onclick = () => {
+        if (players.includes(name)) return;
+        players.push(name);
+        stats[name] = stats[name] || { sum: 0, count: 0 };
+        save();
+        renderPlayers();
+        updatePresetStyles();
+        updateMatrixTable();
+        getPlayerId(name);
+      };
         presetWrapper.appendChild(b);
       });
       updatePresetStyles();
@@ -241,8 +354,10 @@
 
     /* =================== Algoritmo de parejas =================== */
     function generateRound(idx) {
-      const oddOriginal = players.length % 2 === 1;
-      let arr = [...players];
+      const active = players.filter(p => !absents.includes(p));
+      if (active.length < 3) return { pairs: [], solo: null, extremes: null };
+      const oddOriginal = active.length % 2 === 1;
+      let arr = [...active];
       if (oddOriginal) arr.push('DESCANSO');
       const n = arr.length;
 
@@ -291,7 +406,19 @@
       pairs.forEach((p, i) => {
         pairTable.innerHTML += `<tr><td class='border p-2 font-medium bg-gray-50'>Duo ${i + 1}</td><td class='border p-2'>${p[0]} + ${p[1]}</td></tr>`;
       });
-      if (solo) pairTable.innerHTML += `<tr><td class='border p-2 font-medium bg-yellow-100'>Solo</td><td class='border p-2 text-red-600'>${solo}</td></tr>`;
+      if (solo) {
+        pairTable.innerHTML += `<tr><td class='border p-2 font-medium bg-yellow-100'>Solo</td><td class='border p-2 text-red-600'>${solo}</td></tr>`;
+        soloPartnerSel.innerHTML = '<option value="">Elige compañero</option>';
+        players.filter(p => p !== solo && !absents.includes(p)).forEach(n => {
+          const o = document.createElement('option');
+          o.value = n;
+          o.textContent = n;
+          soloPartnerSel.appendChild(o);
+        });
+        soloSection.classList.remove('hidden');
+      } else {
+        soloSection.classList.add('hidden');
+      }
     }
     function renderHistory() {
       historyList.innerHTML = '';
@@ -312,7 +439,8 @@
     /* =================== Matriz de combinaciones =================== */
     const pairKey = (a, b) => [a, b].sort().join('|');
     function updateMatrixTable() {
-      if (players.length < 2) {
+      const active = players.filter(p => !absents.includes(p));
+      if (active.length < 2) {
         matrixTable.innerHTML = '';
         return;
       }
@@ -322,14 +450,14 @@
       });
 
       let html = '<tr><th class="border p-1 bg-gray-200"></th>';
-      players.forEach(p => {
+      active.forEach(p => {
         html += `<th class='border p-1 bg-gray-200 text-[10px] sm:text-xs'>${p}</th>`;
       });
       html += '</tr>';
 
-      players.forEach((p, i) => {
+      active.forEach((p, i) => {
         html += `<tr><th class='border p-1 bg-gray-200 text-[10px] sm:text-xs'>${p}</th>`;
-        players.forEach((q, j) => {
+        active.forEach((q, j) => {
           if (i === j) {
             html += `<td class='border p-1 bg-gray-50'>—</td>`;
           } else if (i < j) {
@@ -347,10 +475,9 @@
     /* =================== Rondas y duplas desde Supabase =================== */
     let roundsData = [];
     async function loadRounds() {
-      const { data, error } = await supa
-        .from('rondas')
-        .select('id, round_num')
-        .order('round_num', { ascending: true });
+      let query = supa.from('rondas').select('id, round_num').order('round_num', { ascending: true });
+      if (currentBirriaId) query = query.eq('birria_id', currentBirriaId);
+      const { data, error } = await query;
       if (error) {
         console.error(error);
         return;
@@ -390,44 +517,95 @@
       };
       buildOpts(selectDuplaA);
       buildOpts(selectDuplaB);
+
+      pairTable.innerHTML = '<tr><th class="border p-2 bg-gray-100">#</th><th class="border p-2 bg-gray-100">Dupla</th></tr>';
+      list.forEach((d, i) => {
+        const a = d.player_a?.name || 'A';
+        const b = d.player_b?.name || 'B';
+        pairTable.innerHTML += `<tr><td class='border p-2 font-medium bg-gray-50'>Duo ${i + 1}</td><td class='border p-2'>${a} + ${b}</td></tr>`;
+      });
+      const r = roundsData.find(r => r.id === rondaId);
+      roundTitle.textContent = r ? `Ronda (${r.round_num}) guardada` : 'Ronda';
     }
 
     /* =================== Eventos =================== */
-    btnAdd.onclick = () => {
-      const n = nameInput.value.trim();
-      if (!n) return;
-      if (players.some(p => p.toLowerCase() === n.toLowerCase())) {
-        alert('Ese jugador ya está en la lista');
-        return;
-      }
-      players.push(n);
-      stats[n] = { sum: 0, count: 0 };
-      nameInput.value = '';
-      save();
-      renderPlayers();
-      updatePresetStyles();
-      updateMatrixTable();
-    };
-    togglePresets.onclick = () => presetList.classList.toggle('hidden');
+      btnAdd.onclick = () => {
+        const n = nameInput.value.trim();
+        if (!n) return;
+        if (players.some(p => p.toLowerCase() === n.toLowerCase())) {
+          alert('Ese jugador ya está en la lista');
+          return;
+        }
+        players.push(n);
+        stats[n] = { sum: 0, count: 0 };
+        nameInput.value = '';
+        save();
+        renderPlayers();
+        updatePresetStyles();
+        updateMatrixTable();
+        getPlayerId(n);
+      };
+      togglePresets.onclick = () => presetList.classList.toggle('hidden');
 
-    nextBtn.onclick = () => {
-      if (players.length < 3) return;
-      const data = generateRound(round);
-      if (data.extremes && lastExtremes && JSON.stringify(data.extremes) === JSON.stringify(lastExtremes) && players.length >= 8) {
+      birriaSelect.onchange = async () => {
+        currentBirriaId = birriaSelect.value || null;
+        const sel = birriaSelect.options[birriaSelect.selectedIndex];
+        birriaInfo.textContent = sel && sel.value ? `Birria ${sel.textContent}` : '';
+        await loadRounds();
+      };
+
+      newBirriaBtn.onclick = async () => {
+        await createBirria();
+        birriaSelect.value = currentBirriaId;
+        history = [];
+        stats = {};
+        round = 0;
+        save();
+        renderHistory();
+        renderPlayers();
+        updateMatrixTable();
+        await loadRounds();
+      };
+
+      nextBtn.onclick = async () => {
+        const active = players.filter(p => !absents.includes(p));
+        if (active.length < 3) return;
+        const data = generateRound(round);
+        if (data.extremes && lastExtremes && JSON.stringify(data.extremes) === JSON.stringify(lastExtremes) && active.length >= 8) {
+          round++;
+          return nextBtn.onclick();
+        }
+        roundTitle.textContent = `Ronda (${round + 1}) actual`;
+        showRound(data);
+        record(data.pairs, data.solo);
+        history.push({ round: round + 1, pairs: data.pairs, solo: data.solo });
+        lastExtremes = data.extremes;
+        save();
+        renderHistory();
+        renderPlayers();
+        updateMatrixTable();
         round++;
-        return nextBtn.onclick();
-      }
-      roundTitle.textContent = `Ronda (${round + 1}) actual`;
-      showRound(data);
-      record(data.pairs, data.solo);
-      history.push({ round: round + 1, pairs: data.pairs, solo: data.solo });
-      lastExtremes = data.extremes;
-      save();
-      renderHistory();
-      renderPlayers();
-      updateMatrixTable();
-      round++;
-    };
+        currentSolo = data.solo;
+        if (currentBirriaId) lastRondaId = await saveRoundToSupabase(data.pairs, round);
+      };
+
+      assignSoloBtn.onclick = async () => {
+        const partner = soloPartnerSel.value;
+        if (!currentSolo || !partner) return;
+        const last = history[history.length - 1];
+        last.pairs.push([currentSolo, partner]);
+        last.solo = null;
+        record([[currentSolo, partner]], null);
+        save();
+        renderHistory();
+        showRound(last);
+        if (lastRondaId) {
+          const aId = await getPlayerId(currentSolo);
+          const bId = await getPlayerId(partner);
+          await supa.from('duplas').insert({ ronda_id: lastRondaId, player_a: aId, player_b: bId, position: last.pairs.length });
+        }
+        currentSolo = null;
+      };
 
     deleteBtn.onclick = () => {
       if (!history.length) return;
@@ -435,6 +613,7 @@
       history.pop();
       if (round > 0) round--;
       lastExtremes = null;
+      currentSolo = null;
       save();
       if (history.length) {
         const last = history[history.length - 1];
@@ -454,8 +633,10 @@
       players = [];
       history = [];
       stats = {};
+      absents = [];
       round = 0;
       lastExtremes = null;
+      currentSolo = null;
       save();
       renderPlayers();
       renderHistory();
@@ -475,7 +656,12 @@
 
     selectRound.onchange = () => {
       const id = selectRound.value;
-      if (id) loadDuplas(id);
+      if (id) {
+        loadDuplas(id);
+      } else {
+        pairTable.innerHTML = '';
+        roundTitle.textContent = 'Sin ronda seleccionada';
+      }
     };
 
     saveMatchBtn.onclick = async () => {
@@ -524,19 +710,21 @@
     const loginBtn = qs('#login-btn');
     const logoutBtn = qs('#logout-btn');
 
-    async function checkAuth() {
-      const { data } = await supa.auth.getSession();
-      console.log('Auth session check:', data.session);
-      if (data.session) {
-        loginSection.classList.add('hidden');
-        appDiv.classList.remove('hidden');
-        await loadRounds();
-      } else {
-        loginSection.classList.remove('hidden');
-        appDiv.classList.add('hidden');
-        matchSection.classList.add('hidden');
+      async function checkAuth() {
+        const { data } = await supa.auth.getSession();
+        console.log('Auth session check:', data.session);
+        if (data.session) {
+          loginSection.classList.add('hidden');
+          appDiv.classList.remove('hidden');
+          birriaSection.classList.remove('hidden');
+          await loadBirrias();
+        } else {
+          loginSection.classList.remove('hidden');
+          appDiv.classList.add('hidden');
+          matchSection.classList.add('hidden');
+          birriaSection.classList.add('hidden');
+        }
       }
-    }
 
     loginBtn.onclick = async () => {
       const { data, error } = await supa.auth.signInWithPassword({


### PR DESCRIPTION
## Summary
- integrate new flow with supabase
- start birria sessions and store rounds and pairs in supabase
- allow registering players to supabase
- add temp absence toggle and solo partner assignment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fc1e30cb4832dbe99164b25f7d591