### PR TITLE
Add public stats page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <header class="text-center">
     <h1 class="text-3xl font-extrabold tracking-tight text-gray-800 drop-shadow-sm">Generador de Duplas – Bádminton</h1>
     <p class="text-sm text-gray-600 mt-1">Gestiona rondas equilibradas y visualiza combinaciones pendientes.</p>
+    <a href="stats.html" class="text-sm text-blue-600 underline">Ver estadísticas</a>
     <button id="logout-btn" class="mt-2 text-sm text-red-600 underline">Cerrar sesión</button>
   </header>
 

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Estadísticas – Bádminton</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+</head>
+<body class="bg-gradient-to-br from-teal-100 via-sky-100 to-fuchsia-100 min-h-screen flex flex-col items-center p-4 gap-6">
+  <header class="text-center">
+    <h1 class="text-3xl font-extrabold tracking-tight text-gray-800 drop-shadow-sm">Estadísticas de Partidos</h1>
+  </header>
+
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md">
+    <h2 class="text-xl font-semibold mb-4">Filtrar por Birria</h2>
+    <select id="birria-select" class="border rounded-xl p-2 w-full mb-2"></select>
+  </section>
+
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md" id="general-section">
+    <h2 class="text-xl font-semibold mb-4">Estadísticas Generales</h2>
+    <table id="stats-table" class="w-full text-sm text-center border-collapse"></table>
+  </section>
+
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md" id="player-section">
+    <h2 class="text-xl font-semibold mb-4">Estadísticas de Jugador</h2>
+    <select id="player-select" class="border rounded-xl p-2 w-full mb-3"></select>
+    <div id="player-info" class="text-sm"></div>
+    <h3 class="text-lg font-semibold mt-4">Duplas ganadoras</h3>
+    <table id="duo-table" class="w-full text-sm text-center border-collapse"></table>
+  </section>
+
+  <script src="stats.js"></script>
+</body>
+</html>

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,139 @@
+const supabaseUrl = 'https://dqaxkapftyoemlzwbjgx.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRxYXhrYXBmdHlvZW1sendiamd4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg5MjEzMzYsImV4cCI6MjA2NDQ5NzMzNn0.onSRsrHzLpFaVYCdrxYoa8uFD2WDcd2H0PdVEUmM8UA';
+const supa = supabase.createClient(supabaseUrl, supabaseKey);
+
+const birriaSelect = document.getElementById('birria-select');
+const statsTable = document.getElementById('stats-table');
+const playerSelect = document.getElementById('player-select');
+const playerInfo = document.getElementById('player-info');
+const duoTable = document.getElementById('duo-table');
+
+let partidas = [];
+let players = new Set();
+let birrias = [];
+
+async function loadBirrias() {
+  const { data, error } = await supa
+    .from('birrias')
+    .select('id, play_date, notes')
+    .order('play_date', { ascending: false });
+  if (error) { console.error(error); return; }
+  birrias = data || [];
+  birriaSelect.innerHTML = '<option value="">Todas las birrias</option>';
+  birrias.forEach(b => {
+    const opt = document.createElement('option');
+    opt.value = b.id;
+    opt.textContent = b.notes || b.play_date;
+    birriaSelect.appendChild(opt);
+  });
+}
+
+async function loadPartidas() {
+  let query = supa
+    .from('partidas')
+    .select('id, score_a, score_b, winner_dupla, ronda(birria_id), dupla_a:dupla_a_id(player_a(name), player_b(name)), dupla_b:dupla_b_id(player_a(name), player_b(name))');
+  const birriaId = birriaSelect.value;
+  if (birriaId) query = query.eq('ronda.birria_id', birriaId);
+  const { data, error } = await query;
+  if (error) { console.error(error); return; }
+  partidas = data || [];
+  players = new Set();
+  partidas.forEach(p => {
+    const a1 = p.dupla_a?.player_a?.name;
+    const a2 = p.dupla_a?.player_b?.name;
+    const b1 = p.dupla_b?.player_a?.name;
+    const b2 = p.dupla_b?.player_b?.name;
+    [a1, a2, b1, b2].forEach(n => { if (n) players.add(n); });
+  });
+  renderGeneral();
+  buildPlayerSelect();
+}
+
+function buildPlayerSelect() {
+  playerSelect.innerHTML = '<option value="">Elige jugador</option>';
+  Array.from(players).sort().forEach(n => {
+    const opt = document.createElement('option');
+    opt.value = n;
+    opt.textContent = n;
+    playerSelect.appendChild(opt);
+  });
+}
+
+function renderGeneral() {
+  const stats = {};
+  partidas.forEach(p => {
+    const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
+    const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
+    const winner = p.winner_dupla === p.dupla_a?.id ? 'A' : (p.winner_dupla === p.dupla_b?.id ? 'B' : null);
+    duoA.forEach(n => {
+      if (!n) return;
+      stats[n] = stats[n] || { wins:0, played:0, points:0 };
+      stats[n].played += 1;
+      stats[n].points += p.score_a || 0;
+      if (winner === 'A') stats[n].wins += 1;
+    });
+    duoB.forEach(n => {
+      if (!n) return;
+      stats[n] = stats[n] || { wins:0, played:0, points:0 };
+      stats[n].played += 1;
+      stats[n].points += p.score_b || 0;
+      if (winner === 'B') stats[n].wins += 1;
+    });
+  });
+  statsTable.innerHTML = '<tr><th class="border p-2 bg-gray-100">Jugador</th><th class="border p-2 bg-gray-100">WinRate</th><th class="border p-2 bg-gray-100">Partidas</th><th class="border p-2 bg-gray-100">Puntos</th></tr>';
+  Object.keys(stats).sort().forEach(n => {
+    const s = stats[n];
+    const winRate = s.played ? ((s.wins / s.played) * 100).toFixed(1) + '%' : '-';
+    statsTable.innerHTML += `<tr><td class='border p-2'>${n}</td><td class='border p-2'>${winRate}</td><td class='border p-2'>${s.played}</td><td class='border p-2'>${s.points}</td></tr>`;
+  });
+}
+
+function renderPlayer(name) {
+  if (!name) {
+    playerInfo.textContent = '';
+    duoTable.innerHTML = '';
+    return;
+  }
+  const info = { wins:0, played:0, points:0 };
+  const duoStats = {};
+  partidas.forEach(p => {
+    const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
+    const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
+    const winA = p.winner_dupla === p.dupla_a?.id;
+    const winB = p.winner_dupla === p.dupla_b?.id;
+    if (duoA.includes(name)) {
+      info.played += 1;
+      info.points += p.score_a || 0;
+      if (winA) info.wins += 1;
+      const mate = duoA[0] === name ? duoA[1] : duoA[0];
+      if (mate) {
+        duoStats[mate] = duoStats[mate] || { wins:0, played:0 };
+        duoStats[mate].played += 1;
+        if (winA) duoStats[mate].wins += 1;
+      }
+    } else if (duoB.includes(name)) {
+      info.played += 1;
+      info.points += p.score_b || 0;
+      if (winB) info.wins += 1;
+      const mate = duoB[0] === name ? duoB[1] : duoB[0];
+      if (mate) {
+        duoStats[mate] = duoStats[mate] || { wins:0, played:0 };
+        duoStats[mate].played += 1;
+        if (winB) duoStats[mate].wins += 1;
+      }
+    }
+  });
+  const winRate = info.played ? ((info.wins / info.played)*100).toFixed(1)+'%' : '-';
+  playerInfo.textContent = `${name}: WinRate ${winRate}, Partidas ${info.played}, Puntos ${info.points}`;
+  duoTable.innerHTML = '<tr><th class="border p-2 bg-gray-100">Compañero</th><th class="border p-2 bg-gray-100">WinRate</th><th class="border p-2 bg-gray-100">Partidas</th></tr>';
+  Object.keys(duoStats).sort().forEach(m => {
+    const s = duoStats[m];
+    const wr = s.played ? ((s.wins/s.played)*100).toFixed(1)+'%' : '-';
+    duoTable.innerHTML += `<tr><td class='border p-2'>${m}</td><td class='border p-2'>${wr}</td><td class='border p-2'>${s.played}</td></tr>`;
+  });
+}
+
+birriaSelect.onchange = loadPartidas;
+playerSelect.onchange = () => renderPlayer(playerSelect.value);
+
+loadBirrias().then(loadPartidas);


### PR DESCRIPTION
## Summary
- add new stats.html page with filters and tables to show general and per-player statistics
- implement stats.js to fetch match info from Supabase and compute win rates
- link to the new stats page from the main index

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fd75fef00832dafd8efad9584036a