### PR TITLE
Fix winrate and update stats UI

### DIFF
--- a/main.js
+++ b/main.js
@@ -696,22 +696,28 @@
         alert('Completa todos los campos correctamente');
         return;
       }
-      const winner = sA >= sB ? duplaA : duplaB;
+      const winner = sA >= sB ? parseInt(duplaA, 10) : parseInt(duplaB, 10);
       let error;
       if (selectMatch.value) {
         ({ error } = await supa
           .from('partidas')
-          .update({ dupla_a_id: duplaA, dupla_b_id: duplaB, score_a: sA, score_b: sB, winner_dupla: winner })
+          .update({
+            dupla_a_id: parseInt(duplaA, 10),
+            dupla_b_id: parseInt(duplaB, 10),
+            score_a: sA,
+            score_b: sB,
+            winner_dupla: winner,
+          })
           .eq('id', selectMatch.value));
       } else {
-        ({ error } = await supa.from('partidas').insert({
-          ronda_id: rondaId,
-          dupla_a_id: duplaA,
-          dupla_b_id: duplaB,
-          score_a: sA,
-          score_b: sB,
-          winner_dupla: winner,
-        }));
+          ({ error } = await supa.from('partidas').insert({
+            ronda_id: rondaId,
+            dupla_a_id: parseInt(duplaA, 10),
+            dupla_b_id: parseInt(duplaB, 10),
+            score_a: sA,
+            score_b: sB,
+            winner_dupla: winner,
+          }));
       }
       if (error) {
         alert('Error al guardar');

--- a/stats.html
+++ b/stats.html
@@ -6,28 +6,35 @@
   <title>Estadísticas – Bádminton</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <style>
+    table tr:nth-child(even) { background-color: #f9fafb; }
+  </style>
 </head>
 <body class="bg-gradient-to-br from-teal-100 via-sky-100 to-fuchsia-100 min-h-screen flex flex-col items-center p-4 gap-6">
   <header class="text-center">
     <h1 class="text-3xl font-extrabold tracking-tight text-gray-800 drop-shadow-sm">Estadísticas de Partidos</h1>
   </header>
 
-  <section class="card bg-white rounded-2xl p-6 w-full max-w-md">
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md shadow-lg">
     <h2 class="text-xl font-semibold mb-4">Filtrar por Birria</h2>
     <select id="birria-select" class="border rounded-xl p-2 w-full mb-2"></select>
   </section>
 
-  <section class="card bg-white rounded-2xl p-6 w-full max-w-md" id="general-section">
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md shadow-lg" id="general-section">
     <h2 class="text-xl font-semibold mb-4">Estadísticas Generales</h2>
-    <table id="stats-table" class="w-full text-sm text-center border-collapse"></table>
+    <div class="overflow-x-auto">
+      <table id="stats-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
+    </div>
   </section>
 
-  <section class="card bg-white rounded-2xl p-6 w-full max-w-md" id="player-section">
+  <section class="card bg-white rounded-2xl p-6 w-full max-w-md shadow-lg" id="player-section">
     <h2 class="text-xl font-semibold mb-4">Estadísticas de Jugador</h2>
     <select id="player-select" class="border rounded-xl p-2 w-full mb-3"></select>
     <div id="player-info" class="text-sm"></div>
     <h3 class="text-lg font-semibold mt-4">Duplas ganadoras</h3>
-    <table id="duo-table" class="w-full text-sm text-center border-collapse"></table>
+    <div class="overflow-x-auto">
+      <table id="duo-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
+    </div>
   </section>
 
   <script src="stats.js"></script>

--- a/stats.js
+++ b/stats.js
@@ -44,7 +44,8 @@ function computeElo(matches) {
     const eloA = (ratings[a1] + ratings[a2]) / 2;
     const eloB = (ratings[b1] + ratings[b2]) / 2;
     const expectedA = expectedScore(eloA, eloB);
-    const winA = m.winner_dupla === m.dupla_a?.id;
+    const winnerId = parseInt(m.winner_dupla, 10);
+    const winA = winnerId === m.dupla_a?.id;
     const scoreA = winA ? 1 : 0;
     const delta = K_FACTOR * (scoreA - expectedA);
 
@@ -109,7 +110,8 @@ function renderGeneral() {
   partidas.forEach(p => {
     const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
     const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
-    const winner = p.winner_dupla === p.dupla_a?.id ? 'A' : (p.winner_dupla === p.dupla_b?.id ? 'B' : null);
+    const winnerId = parseInt(p.winner_dupla, 10);
+    const winner = winnerId === p.dupla_a?.id ? 'A' : (winnerId === p.dupla_b?.id ? 'B' : null);
     duoA.forEach(n => {
       if (!n) return;
       stats[n] = stats[n] || { wins:0, played:0, points:0 };
@@ -146,8 +148,9 @@ function renderPlayer(name) {
   partidas.forEach(p => {
     const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
     const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
-    const winA = p.winner_dupla === p.dupla_a?.id;
-    const winB = p.winner_dupla === p.dupla_b?.id;
+    const winnerId = parseInt(p.winner_dupla, 10);
+    const winA = winnerId === p.dupla_a?.id;
+    const winB = winnerId === p.dupla_b?.id;
     if (duoA.includes(name)) {
       info.played += 1;
       info.points += p.score_a || 0;


### PR DESCRIPTION
## Summary
- fix comparisons in win rate calculations
- ensure match insert/update uses numeric IDs
- improve styling of the statistics page

## Testing
- `node --check stats.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6840aa09f074832dbce9654c74116039