### PR TITLE
Oculta datos hasta elegir birria

### DIFF
--- a/main.js
+++ b/main.js
@@ -792,7 +792,13 @@
           birriaSection.classList.remove('hidden');
           await loadBirrias();
           await refreshStatsFromDB();
-          renderPlayers();
+          playerSection.classList.add('hidden');
+          roundSection.classList.add('hidden');
+          qs('#history-section').classList.add('hidden');
+          matrixSection.classList.add('hidden');
+          matchSection.classList.add('hidden');
+          pairTable.innerHTML = '';
+          roundTitle.textContent = 'Sin ronda seleccionada';
         } else {
           loginSection.classList.remove('hidden');
           appDiv.classList.add('hidden');
@@ -828,6 +834,3 @@
 
     /* =================== Init =================== */
     buildPresetButtons();
-    renderPlayers();
-    renderHistory();
-    updateMatrixTable();


### PR DESCRIPTION
## Summary
- evita mostrar jugadores e historial al iniciar sesión
- ajusta la inicialización para que las secciones aparezcan solo tras elegir o crear birria

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b4700090832d898deaadd1a2e282