### PR TITLE
Fix winrate computation with UUID ids

### DIFF
--- a/main.js
+++ b/main.js
@@ -696,14 +696,14 @@
         alert('Completa todos los campos correctamente');
         return;
       }
-      const winner = sA >= sB ? parseInt(duplaA, 10) : parseInt(duplaB, 10);
+      const winner = sA >= sB ? duplaA : duplaB;
       let error;
       if (selectMatch.value) {
         ({ error } = await supa
           .from('partidas')
           .update({
-            dupla_a_id: parseInt(duplaA, 10),
-            dupla_b_id: parseInt(duplaB, 10),
+            dupla_a_id: duplaA,
+            dupla_b_id: duplaB,
             score_a: sA,
             score_b: sB,
             winner_dupla: winner,
@@ -712,8 +712,8 @@
       } else {
           ({ error } = await supa.from('partidas').insert({
             ronda_id: rondaId,
-            dupla_a_id: parseInt(duplaA, 10),
-            dupla_b_id: parseInt(duplaB, 10),
+            dupla_a_id: duplaA,
+            dupla_b_id: duplaB,
             score_a: sA,
             score_b: sB,
             winner_dupla: winner,

--- a/stats.js
+++ b/stats.js
@@ -44,7 +44,7 @@ function computeElo(matches) {
     const eloA = (ratings[a1] + ratings[a2]) / 2;
     const eloB = (ratings[b1] + ratings[b2]) / 2;
     const expectedA = expectedScore(eloA, eloB);
-    const winnerId = parseInt(m.winner_dupla, 10);
+    const winnerId = m.winner_dupla;
     const winA = winnerId === m.dupla_a?.id;
     const scoreA = winA ? 1 : 0;
     const delta = K_FACTOR * (scoreA - expectedA);
@@ -112,7 +112,7 @@ function renderGeneral() {
   partidas.forEach(p => {
     const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
     const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
-    const winnerId = parseInt(p.winner_dupla, 10);
+    const winnerId = p.winner_dupla;
     const winner = winnerId === p.dupla_a?.id ? 'A' : (winnerId === p.dupla_b?.id ? 'B' : null);
     duoA.forEach(n => {
       if (!n) return;
@@ -155,7 +155,7 @@ function renderPlayer(name) {
   partidas.forEach(p => {
     const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
     const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
-    const winnerId = parseInt(p.winner_dupla, 10);
+    const winnerId = p.winner_dupla;
     const winA = winnerId === p.dupla_a?.id;
     const winB = winnerId === p.dupla_b?.id;
     if (duoA.includes(name)) {


### PR DESCRIPTION
## Summary
- handle UUID IDs when saving and reading matches
- remove `parseInt` calls

## Testing
- `node -c main.js`
- `node -c stats.js`


------
https://chatgpt.com/codex/tasks/task_e_6840b5556ee8832dbe72d1f4853b8259