### PR TITLE
Fix birria filter on stats page

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -76,7 +76,8 @@ async function loadBirrias() {
 async function loadPartidas() {
   let query = supa
     .from('partidas')
-    .select(`id, score_a, score_b, winner_dupla, rondas(birria_id),
+    .select(`id, score_a, score_b, winner_dupla, ronda_id,
+      rondas!inner(birria_id),
       dupla_a:dupla_a_id(id, player_a(name), player_b(name)),
       dupla_b:dupla_b_id(id, player_a(name), player_b(name))`);
   const birriaId = birriaSelect.value;


### PR DESCRIPTION
## Summary
- fix filtering by birria in statistics page by joining `rondas` table as `inner`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbf20924832d8b49fe4889b359db