### PR TITLE
Refine pairing logic and clean up solo UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,6 @@
     <div class="overflow-x-auto">
       <table id="pairings-table" class="w-full text-sm text-center border-collapse"></table>
     </div>
-    <div id="solo-section" class="mt-4 flex items-center gap-2 hidden">
-      <label for="solo-partner" class="text-sm">Asignar compañero al solo</label>
-      <select id="solo-partner" class="border rounded-xl p-2"></select>
-      <button id="assign-solo" class="bg-blue-600 hover:bg-blue-700 text-white rounded-xl p-2 text-sm font-medium">Asignar</button>
-    </div>
   </section>
 
   <!-- 4. Historial -->


### PR DESCRIPTION
## Summary
- keep track of previous pairings to reduce repeats
- shuffle active players to break patterns
- pick resting player based on previous solos
- drop UI for assigning a partner to the solo player in the same round

## Testing
- `node --check main.js`
- `node -e "require('./main.js')"` *(fails: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_6841143297fc832daa8499c6d87c5b75