### PR TITLE
Fix missing mathjs import in stats

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -6,6 +6,15 @@
   <title>Estadísticas – Bádminton</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "mathjs": "https://cdn.jsdelivr.net/npm/mathjs@13.2.0/+esm",
+        "ts-gaussian": "https://cdn.jsdelivr.net/npm/ts-gaussian@3/+esm",
+        "uuid": "https://cdn.jsdelivr.net/npm/uuid@11/+esm"
+      }
+    }
+  </script>
   <style>
     table tr:nth-child(even) { background-color: #f9fafb; }
   </style>
@@ -39,6 +48,6 @@
     </div>
   </section>
 
-  <script src="stats.js"></script>
+  <script type="module" src="stats.js"></script>
 </body>
 </html>

--- a/stats.js
+++ b/stats.js
@@ -4,7 +4,6 @@ const supa = supabase.createClient(supabaseUrl, supabaseKey);
 
 // ----- Parámetros de Elo (inspirados en el script en Python) -----
 const ELO_INITIAL = 875;
-const K_FACTOR = 32;
 const UMBRAL_ELO_B = 850;
 const UMBRAL_ELO_A = 1000;
 


### PR DESCRIPTION
## Summary
- add an import map so ts-trueskill can resolve mathjs and friends
- clean up unused constant in stats.js
- load stats.js as module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841b8920aac832d8961a21170bfb13e