### PR TITLE
Add dynamic grouping and match filter

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -31,6 +31,13 @@
 
   <section class="card bg-white rounded-2xl p-6 w-full max-w-md shadow-lg" id="general-section">
     <h2 class="text-xl font-semibold mb-4">Estadísticas Generales</h2>
+    <label for="min-games" class="text-sm text-gray-600">Partidas mínimas:</label>
+    <select id="min-games" class="border rounded-xl p-2 w-full mb-3">
+      <option value="0">Todas</option>
+      <option value="25">25+</option>
+      <option value="50">50+</option>
+      <option value="100">100+</option>
+    </select>
     <div class="overflow-x-auto">
       <table id="stats-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
     </div>


### PR DESCRIPTION
## Summary
- dynamically compute player groups based on the mean and standard deviation of the TrueSkill ratings
- allow filtering the general table by minimum number of matches

## Testing
- `node --check stats.js`

------
https://chatgpt.com/codex/tasks/task_e_6841ba782b18832d8e4989bfffbd6f24