### PR TITLE
Add player H2H stats and TrueSkill chart

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -12,6 +12,7 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script type="importmap">
     {
       "imports": {
@@ -65,6 +66,12 @@
     <div class="overflow-x-auto">
       <table id="duo-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
     </div>
+    <h3 class="text-lg font-semibold mt-4">Head to Head</h3>
+    <div class="overflow-x-auto mb-3">
+      <table id="h2h-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
+    </div>
+    <h3 class="text-lg font-semibold mt-4">Evolución TrueSkill</h3>
+    <canvas id="ts-chart" class="w-full h-64"></canvas>
   </section>
 
   <script type="module" src="stats.js"></script>


### PR DESCRIPTION
## Summary
- include Chart.js for new charts
- show H2H stats table in player section
- compute and plot TrueSkill rating over time for each player

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68420496f564832d9aff00a78058dd51