### PR TITLE
Handle solo players without schema change

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@
     async function refreshStatsFromDB() {
       let query = supa
         .from('duplas')
-        .select('position, ronda_id, rondas!inner(birria_id, solo_player), player_a(name), player_b(name)');
+        .select('position, ronda_id, rondas!inner(birria_id), player_a(name), player_b(name)');
       if (currentBirriaId) query = query.eq('rondas.birria_id', currentBirriaId);
       const { data, error } = await query;
       if (error) { console.error(error); return; }
@@ -132,14 +132,9 @@
           pSet.add(n);
         });
       });
-      const { data: rounds } = await supa
-        .from('rondas')
-        .select('id, solo:solo_player(name)')
-        .in('id', Object.keys(maxPos));
-      (rounds || []).forEach(r => {
-        const soloName = r.solo?.name || soloMap[r.id];
+      Object.entries(soloMap).forEach(([id, soloName]) => {
+        const pos = maxPos[id] || 0;
         if (!soloName) return;
-        const pos = maxPos[r.id] || 0;
         stats[soloName] = stats[soloName] || { sum: 0, count: 0 };
         stats[soloName].sum += pos;
         stats[soloName].count += 1;
@@ -173,7 +168,6 @@
       let soloId = null;
       if (solo) {
         soloId = await getPlayerId(solo);
-        fields.solo_player = soloId;
       }
       let { data, error } = await supa.from('rondas').insert(fields).select('id').single();
       if (error) { console.error(error); return; }
@@ -566,13 +560,13 @@
       }
       const { data, error } = await supa
         .from('rondas')
-        .select('round_num, solo:solo_player(name), duplas(position, player_a(name), player_b(name))')
+        .select('round_num, duplas(position, player_a(name), player_b(name))')
         .eq('birria_id', currentBirriaId)
         .order('round_num');
       if (error) { console.error(error); return; }
       history = (data || []).map(r => {
         const pairs = [];
-        let solo = r.solo?.name || null;
+        let solo = null;
         (r.duplas || [])
           .sort((a,b)=>a.position-b.position)
           .forEach(d => {

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,56 @@
+-- SQL script to create the database schema
+
+-- =========================================================================
+--  \ud83c\udfc8  Esquema “Birria → Ronda → Dupla → Partida”  (Versi\u00f3n 2025-06-02)
+-- =========================================================================
+--  Todas las tablas usan UUID autogenerado con la extensión pgcrypto.
+--  RLS (Row-Level Security) se mantiene desactivado.
+
+-- Asegúrate de que la extensión pgcrypto está habilitada
+create extension if not exists "pgcrypto";
+
+-- 1) Jugadores ------------------------------------------------------------
+create table if not exists players (
+  id   uuid primary key default gen_random_uuid(),
+  name text unique not null
+);
+
+-- 2) Birrias (sesiones completas) ----------------------------------------
+create table if not exists birrias (
+  id         uuid primary key default gen_random_uuid(),
+  play_date  date not null,
+  notes      text
+);
+
+-- 3) Rondas dentro de la Birria -----------------------------------------
+create table if not exists rondas (
+  id         uuid primary key default gen_random_uuid(),
+  birria_id  uuid not null references birrias(id) on delete cascade,
+  round_num  int  not null,
+  unique (birria_id, round_num)
+);
+
+-- 4) Duplas generadas para la ronda -------------------------------------
+create table if not exists duplas (
+  id          uuid primary key default gen_random_uuid(),
+  ronda_id    uuid not null references rondas(id) on delete cascade,
+  player_a    uuid not null references players(id),
+  player_b    uuid not null references players(id),
+  position    int  not null,
+  unique (ronda_id, position),
+  unique (ronda_id, player_a, player_b)
+);
+
+-- 5) Partidas 2 vs 2 -----------------------------------------------------
+create table if not exists partidas (
+  id            uuid primary key default gen_random_uuid(),
+  ronda_id      uuid not null references rondas(id) on delete cascade,
+  dupla_a_id    uuid not null references duplas(id),
+  dupla_b_id    uuid not null references duplas(id),
+  score_a       int  not null check (score_a >= 0),
+  score_b       int  not null check (score_b >= 0),
+  winner_dupla  uuid not null references duplas(id),
+  check (winner_dupla in (dupla_a_id, dupla_b_id))
+);
+
+-- Opcional: habilita RLS más adelante si es necesario.


### PR DESCRIPTION
## Summary
- revert schema to original without `solo_player`
- compute solo rounds based on dummy pair only
- ignore dummy pairs in statistics

## Testing
- `node -c main.js && node -c stats.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68434feab2ec832da1c75eec2e0c96e4