### PR TITLE
Add recent matches table to stats

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -72,6 +72,10 @@
     </div>
     <h3 class="text-lg font-semibold mt-4">Evolución TrueSkill</h3>
     <canvas id="ts-chart" class="w-full h-64"></canvas>
+    <h3 class="text-lg font-semibold mt-4">Últimas 20 partidas</h3>
+    <div class="overflow-x-auto mb-3">
+      <table id="recent-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
+    </div>
   </section>
 
   <script type="module" src="stats.js"></script>


### PR DESCRIPTION
## Summary
- show a new "Últimas 20 partidas" table in the stats page
- update stats.js to load date information and render recent matches

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858aad66008832da8abee2a8d7eff03