### PR TITLE
Fix stats and history state handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -555,8 +555,8 @@
     }
 
     async function loadHistoryFromDB() {
-      history = [];
       if (!currentBirriaId) {
+        history = [];
         round = 0;
         save();
         renderHistory();

--- a/stats.html
+++ b/stats.html
@@ -72,7 +72,7 @@
     </div>
     <h3 class="text-lg font-semibold mt-4">Evolución TrueSkill</h3>
     <canvas id="ts-chart" class="w-full h-64"></canvas>
-    <h3 class="text-lg font-semibold mt-4">Últimas 20 partidas</h3>
+      <h3 class="text-lg font-semibold mt-4">Partidas</h3>
     <div class="overflow-x-auto mb-3">
       <table id="recent-table" class="min-w-full text-sm text-center border-collapse rounded-lg overflow-hidden shadow-md"></table>
     </div>

--- a/stats.js
+++ b/stats.js
@@ -262,28 +262,31 @@ function renderPlayer(name) {
     });
 
   recentTable.innerHTML = '<tr><th class="border p-2 bg-gray-100">Fecha</th><th class="border p-2 bg-gray-100">Dupla A</th><th class="border p-2 bg-gray-100">Dupla B</th><th class="border p-2 bg-gray-100">Marcador</th><th class="border p-2 bg-gray-100">Ganadores</th></tr>';
+  const selectedBirria = birriaSelect.value;
+  const lastBirriaId = birrias[0]?.id;
   const recent = partidas
     .filter(p => {
       const duoA = [p.dupla_a?.player_a?.name, p.dupla_a?.player_b?.name];
       const duoB = [p.dupla_b?.player_a?.name, p.dupla_b?.player_b?.name];
       if (duoA.includes(SOLO_DUMMY) || duoB.includes(SOLO_DUMMY)) return false;
-      return duoA.includes(name) || duoB.includes(name);
+      const inPlayer = duoA.includes(name) || duoB.includes(name);
+      if (!inPlayer) return false;
+      const bid = p.rondas?.birria_id;
+      if (selectedBirria) return bid === selectedBirria;
+      if (lastBirriaId) return bid === lastBirriaId; // general -> last birria
+      return true;
     })
-    .map(p => {
-      const birria = birrias.find(b => b.id === p.rondas?.birria_id);
-      return {
-        partida: p,
-        date: birria?.play_date,
-        round: p.rondas?.round_num ?? 0
-      };
-    })
+    .map(p => ({
+      partida: p,
+      date: p.rondas?.birrias?.play_date,
+      round: p.rondas?.round_num ?? 0
+    }))
     .sort((a, b) => {
       const d1 = a.date ? new Date(a.date) : new Date(0);
       const d2 = b.date ? new Date(b.date) : new Date(0);
       if (d1.getTime() !== d2.getTime()) return d2 - d1;
       return b.round - a.round;
-    })
-    .slice(0, 20);
+    });
 
   recent.forEach(({ partida: m, date }) => {
     const a1 = m.dupla_a?.player_a?.name;


### PR DESCRIPTION
## Summary
- preserve history when DB load fails
- read match dates directly from rounds join when showing recent matches
- show all matches for a selected birria and the latest birria for general view

## Testing
- `node -c main.js`
- `node -c stats.js`


------
https://chatgpt.com/codex/tasks/task_e_6858ac1e995c832d8d110efe3812950d